### PR TITLE
Changing getOpacity method to return PixelFormat

### DIFF
--- a/app/src/main/java/io/github/ryanhoo/music/ui/widget/CharacterDrawable.java
+++ b/app/src/main/java/io/github/ryanhoo/music/ui/widget/CharacterDrawable.java
@@ -92,7 +92,7 @@ public class CharacterDrawable extends Drawable {
     @Override
     public int getOpacity() {
         // TODO
-        return 0;
+        return PixelFormat.UNKNOWN;
     }
 
     // Getters & Setters


### PR DESCRIPTION
Android Studio was throwing an error for the `return 0` suggesting to use constant from the PixelFormat class of the android.graphics package
